### PR TITLE
Fix: Unbreak the configs for 0.8.1 changes.

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ No modules.
 |------|------|
 | [apko_build.this](https://registry.terraform.io/providers/chainguard-dev/apko/latest/docs/resources/build) | resource |
 | [cosign_sign.signature](https://registry.terraform.io/providers/chainguard-dev/cosign/latest/docs/resources/sign) | resource |
+| [apko_config.this](https://registry.terraform.io/providers/chainguard-dev/apko/latest/docs/data-sources/config) | data source |
 
 ## Inputs
 

--- a/main.tf
+++ b/main.tf
@@ -14,18 +14,18 @@ terraform {
   }
 }
 
+data "apko_config" "this" {
+  config_contents = var.config
+}
+
 resource "apko_build" "this" {
   repo   = var.target_repository
-  config = var.config
+  config = data.apko_config.this.config
 }
 
 resource "cosign_sign" "signature" {
   image = apko_build.this.image_ref
 }
-
-# data "apko_config" "this" {
-#   config = var.config
-# }
 
 # resource "cosign_attest" "sboms" {
 #   for_each = toset(concat(data.apko_config.this.data.archs, ["index"]))


### PR DESCRIPTION
:bug: The 0.8.1 release introduces a new data source, which must feed the `apko_build` with the resolved configuration.

/kind bug