### PR TITLE
pipe through default_annotations to apko_config

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ No modules.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_config"></a> [config](#input\_config) | The apko configuration file to build and publish. | `any` | n/a | yes |
+| <a name="input_default_annotations"></a> [default\_annotations](#input\_default\_annotations) | Default annotations to apply to this image. | `map(string)` | `{}` | no |
 | <a name="input_extra_packages"></a> [extra\_packages](#input\_extra\_packages) | Additional packages to install into this image. | `list(string)` | `[]` | no |
 | <a name="input_target_repository"></a> [target\_repository](#input\_target\_repository) | The docker repo into which the image and attestations should be published. | `any` | n/a | yes |
 

--- a/examples/static/example.tf
+++ b/examples/static/example.tf
@@ -26,13 +26,17 @@ provider "apko" {
 }
 
 module "image" {
-  source  = "../.."
+  source = "../.."
 
   target_repository = var.target_repository
-  config = file("${path.module}/static.yaml")
+  config            = file("${path.module}/static.yaml")
 
   # Simulate a "dev" variant
   extra_packages = ["busybox"]
+
+  default_annotations = {
+    "org.opencontainers.image.source" = "https://github.com/chainguard-dev/terraform-publisher-apko/examples/${basename(path.cwd)}"
+  }
 }
 
 data "cosign_verify" "image-signatures" {
@@ -88,7 +92,7 @@ data "cosign_verify" "sbom-attestations" {
         }
         attestations = [
           {
-            name = "spdx-att"
+            name          = "spdx-att"
             predicateType = "https://spdx.dev/Document"
             policy = {
               type = "cue"
@@ -127,7 +131,7 @@ data "cosign_verify" "config-attestations" {
         }
         attestations = [
           {
-            name = "config-att"
+            name          = "config-att"
             predicateType = "https://apko.dev/image-configuration"
             policy = {
               type = "cue"

--- a/main.tf
+++ b/main.tf
@@ -15,8 +15,9 @@ terraform {
 }
 
 data "apko_config" "this" {
-  config_contents = var.config
-  extra_packages  = var.extra_packages
+  config_contents     = var.config
+  extra_packages      = var.extra_packages
+  default_annotations = var.default_annotations
 }
 
 resource "apko_build" "this" {
@@ -90,6 +91,6 @@ resource "cosign_attest" "slsa-provenance" {
     }
   })
 
-  # Avoid racing with ako-configuration to publish attestations.
+  # Avoid racing with apko-configuration to publish attestations.
   depends_on = [cosign_attest.apko-configuration]
 }

--- a/variables.tf
+++ b/variables.tf
@@ -16,3 +16,9 @@ variable "extra_packages" {
 variable "config" {
   description = "The apko configuration file to build and publish."
 }
+
+variable "default_annotations" {
+  type        = map(string)
+  default     = {}
+  description = "Default annotations to apply to this image."
+}


### PR DESCRIPTION
```
$ terraform plan -var=target_repository=ttl.sh/jason
...
+ annotations = {
    + "org.opencontainers.image.source" = "https://github.com/chainguard-dev/terraform-publisher-apko/examples/static"
}
...
```

Also fmt and fix a typo