### PR TITLE
Always attest the index.

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -30,7 +30,7 @@ resource "cosign_sign" "signature" {
 }
 
 locals {
-  archs = toset(concat(data.apko_config.this.config.archs, length(data.apko_config.this.config.archs) > 1 ? ["index"] : []))
+  archs = toset(concat(["index"], data.apko_config.this.config.archs))
 }
 
 resource "cosign_attest" "this" {


### PR DESCRIPTION
Previously we only produced an index when the image had multiple architectures, but for consistency with `apko` we now produce a single-architecture index in those cases.

For this to work properly we must always attest SBOMs and such.