### PR TITLE
chore: add note about the diff api dependency on this module

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -25,6 +25,7 @@ resource "apko_build" "this" {
   config = data.apko_config.this.config
 }
 
+# NOTE: The Diff API vulnerability scan generator depends on signature push events to happen on daily basis for every rebuilt image.
 resource "cosign_sign" "signature" {
   image = apko_build.this.image_ref
 


### PR DESCRIPTION
The Diff API depends on this module to publish the signatures so our service generates fresh scan reports from the existing images.