### PR TITLE
add spdx validity check

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,8 @@ No modules.
 | [cosign_attest.this](https://registry.terraform.io/providers/chainguard-dev/cosign/latest/docs/resources/attest) | resource |
 | [cosign_sign.signature](https://registry.terraform.io/providers/chainguard-dev/cosign/latest/docs/resources/sign) | resource |
 | [apko_config.this](https://registry.terraform.io/providers/chainguard-dev/apko/latest/docs/data-sources/config) | data source |
-| [oci_exec_test.check-sbom](https://registry.terraform.io/providers/chainguard-dev/oci/latest/docs/data-sources/exec_test) | data source |
+| [oci_exec_test.check-sbom-ntia](https://registry.terraform.io/providers/chainguard-dev/oci/latest/docs/data-sources/exec_test) | data source |
+| [oci_exec_test.check-sbom-spdx](https://registry.terraform.io/providers/chainguard-dev/oci/latest/docs/data-sources/exec_test) | data source |
 
 ## Inputs
 
@@ -45,6 +46,7 @@ No modules.
 | <a name="input_extra_packages"></a> [extra\_packages](#input\_extra\_packages) | Additional packages to install into this image. | `list(string)` | `[]` | no |
 | <a name="input_sbom_checker"></a> [sbom\_checker](#input\_sbom\_checker) | The NTIA conformance checker image to use to validate SBOMs. | `string` | `"cgr.dev/chainguard/ntia-conformance-checker:latest"` | no |
 | <a name="input_skip_attest"></a> [skip\_attest](#input\_skip\_attest) | If true, skip the attestations step. This is NOT RECOMMENDED, and should only be used when attestations may be too big for Rekor. | `bool` | `false` | no |
+| <a name="input_spdx_image"></a> [spdx\_image](#input\_spdx\_image) | The SPDX checker image to use to validate SBOMs. | `string` | `"cgr.dev/chainguard/wolfi-base:latest"` | no |
 | <a name="input_target_repository"></a> [target\_repository](#input\_target\_repository) | The docker repo into which the image and attestations should be published. | `any` | n/a | yes |
 
 ## Outputs

--- a/main.tf
+++ b/main.tf
@@ -30,23 +30,40 @@ resource "cosign_sign" "signature" {
   conflict = "REPLACE"
 }
 
-locals {
-  archs = toset(concat(["index"], data.apko_config.this.config.archs))
-}
+locals { archs = toset(concat(["index"], data.apko_config.this.config.archs)) }
 
-data "oci_exec_test" "check-sbom" {
+data "oci_exec_test" "check-sbom-ntia" {
   for_each = var.check_sbom ? local.archs : []
   digest   = apko_build.this.sboms[each.key].digest
 
-  # Run the supplied NTIA checker over the SBOM files mounted into the checker image in a readonly mode.
+  # Run the supplied NTIA checker over the SBOM file mounted into the checker image in a readonly mode.
   # We run as root to avoid permission issues reading the SBOM as the default nonroot user.
   script = "docker run --rm --user 0 -v ${apko_build.this.sboms[each.key].predicate_path}:/sbom.json:ro ${var.sbom_checker} -v --file /sbom.json"
+}
+
+data "oci_exec_test" "check-sbom-spdx" {
+  for_each = var.check_sbom != "" ? local.archs : []
+  digest   = apko_build.this.sboms[each.key].digest
+
+  # Run the supplied SPDX checker over the SBOM file mounted into the image in a readonly mode.
+  # We run as root to avoid permission issues reading the SBOM as the default nonroot user.
+  # TODO(jason): Build a new image with the spdx-tools-java package pre-installed.
+  script = <<EOF
+  docker run --rm --user 0 \
+      -v ${apko_build.this.sboms[each.key].predicate_path}:/sbom.json:ro \
+      --entrypoint sh \
+      ${var.spdx_image} \
+      -c "apk add spdx-tools-java && tools-java Verify /sbom.json"
+  EOF
 }
 
 resource "cosign_attest" "this" {
   for_each = var.skip_attest ? [] : local.archs
 
-  depends_on = [data.oci_exec_test.check-sbom]
+  depends_on = [
+    data.oci_exec_test.check-sbom-ntia,
+    data.oci_exec_test.check-sbom-spdx,
+  ]
 
   image = apko_build.this.sboms[each.key].digest
 

--- a/variables.tf
+++ b/variables.tf
@@ -33,6 +33,11 @@ variable "sbom_checker" {
   description = "The NTIA conformance checker image to use to validate SBOMs."
 }
 
+variable "spdx_image" {
+  default     = "cgr.dev/chainguard/wolfi-base:latest"
+  description = "The SPDX checker image to use to validate SBOMs."
+}
+
 variable "skip_attest" {
   description = "If true, skip the attestations step. This is NOT RECOMMENDED, and should only be used when attestations may be too big for Rekor."
   default     = false


### PR DESCRIPTION
This adds a check that the image SBOMs are _valid SPDX_. The existing NTIA check only checks for the NTIA minimum conformant elements, but doesn't (apparently) actually check for valid SPDX data. This new check covers that.