### PR TITLE
fix SPDX test when check_sbom=false

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,6 +1,8 @@
 name: Tests
 on:
-  pull_request_target:
+  pull_request_target: # To test cosign signing.
+    branches: ['main']
+  pull_request:
     branches: ['main']
   push:
     branches: ['main']
@@ -9,12 +11,6 @@ jobs:
   test:
     name: Test
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        example:
-        - 'static'
-
     permissions:
       contents: read
       id-token: write
@@ -37,17 +33,17 @@ jobs:
         terraform_version: '1.8.*'
         terraform_wrapper: false
 
-    - working-directory: ./examples/${{ matrix.example }}
+    - working-directory: ./examples/static
       env:
-        TF_VAR_target_repository: localhost:5000/${{ matrix.example }}
+        TF_VAR_target_repository: localhost:5000/static
       run: |
         terraform init -upgrade
         terraform apply -auto-approve
 
     # Test with archs and check_sbom=false
-    - working-directory: ./examples/${{ matrix.example }}
+    - working-directory: ./examples/static
       env:
-        TF_VAR_target_repository: localhost:5000/${{ matrix.example }}
+        TF_VAR_target_repository: localhost:5000/static
         TF_VAR_archs: '["x86_64"]'
         TF_VAR_check_sbom: 'false'
       run: |

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -36,6 +36,7 @@ jobs:
     - working-directory: ./examples/static
       env:
         TF_VAR_target_repository: localhost:5000/static
+        TF_VAR_verify: ${{github.event_name == 'pull_request_target'}}
       run: |
         terraform init -upgrade
         terraform apply -auto-approve
@@ -46,6 +47,7 @@ jobs:
         TF_VAR_target_repository: localhost:5000/static
         TF_VAR_archs: '["x86_64"]'
         TF_VAR_check_sbom: 'false'
+        TF_VAR_verify: ${{github.event_name == 'pull_request_target'}}
       run: |
         terraform init -upgrade
         terraform apply -auto-approve

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -26,7 +26,7 @@ jobs:
 
     - uses: actions/setup-go@v5
       with:
-        go-version: '1.18'
+        go-version: '1.22'
 
     - uses: chainguard-dev/actions/setup-registry@main
       with:
@@ -34,11 +34,22 @@ jobs:
 
     - uses: hashicorp/setup-terraform@v3
       with:
-        terraform_version: '1.3.*'
+        terraform_version: '1.8.*'
         terraform_wrapper: false
 
     - working-directory: ./examples/${{ matrix.example }}
+      env:
+        TF_VAR_target_repository: localhost:5000/${{ matrix.example }}
       run: |
-        export TF_VAR_target_repository=localhost:5000/${{ matrix.example }}
+        terraform init -upgrade
+        terraform apply -auto-approve
+
+    # Test with archs and check_sbom=false
+    - working-directory: ./examples/${{ matrix.example }}
+      env:
+        TF_VAR_target_repository: localhost:5000/${{ matrix.example }}
+        TF_VAR_archs: '["x86_64"]'
+        TF_VAR_check_sbom: 'false'
+      run: |
         terraform init -upgrade
         terraform apply -auto-approve

--- a/README.md
+++ b/README.md
@@ -41,13 +41,13 @@ No modules.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_check_sbom"></a> [check\_sbom](#input\_check\_sbom) | Whether to run the NTIA conformance checker on the SBOMs we are attesting. | `bool` | `true` | no |
-| <a name="input_config"></a> [config](#input\_config) | The apko configuration file to build and publish. | `any` | n/a | yes |
+| <a name="input_config"></a> [config](#input\_config) | The apko configuration file contents to build and publish. | `string` | n/a | yes |
 | <a name="input_default_annotations"></a> [default\_annotations](#input\_default\_annotations) | Default annotations to apply to this image. | `map(string)` | `{}` | no |
 | <a name="input_extra_packages"></a> [extra\_packages](#input\_extra\_packages) | Additional packages to install into this image. | `list(string)` | `[]` | no |
 | <a name="input_sbom_checker"></a> [sbom\_checker](#input\_sbom\_checker) | The NTIA conformance checker image to use to validate SBOMs. | `string` | `"cgr.dev/chainguard/ntia-conformance-checker:latest"` | no |
 | <a name="input_skip_attest"></a> [skip\_attest](#input\_skip\_attest) | If true, skip the attestations step. This is NOT RECOMMENDED, and should only be used when attestations may be too big for Rekor. | `bool` | `false` | no |
 | <a name="input_spdx_image"></a> [spdx\_image](#input\_spdx\_image) | The SPDX checker image to use to validate SBOMs. | `string` | `"cgr.dev/chainguard/wolfi-base:latest"` | no |
-| <a name="input_target_repository"></a> [target\_repository](#input\_target\_repository) | The docker repo into which the image and attestations should be published. | `any` | n/a | yes |
+| <a name="input_target_repository"></a> [target\_repository](#input\_target\_repository) | The docker repo into which the image and attestations should be published. | `string` | n/a | yes |
 
 ## Outputs
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ No requirements.
 |------|---------|
 | <a name="provider_apko"></a> [apko](#provider\_apko) | n/a |
 | <a name="provider_cosign"></a> [cosign](#provider\_cosign) | n/a |
-| <a name="provider_oci"></a> [oci](#provider\_oci) | n/a |
+| <a name="provider_null"></a> [null](#provider\_null) | n/a |
 
 ## Modules
 

--- a/README.md
+++ b/README.md
@@ -32,9 +32,9 @@ No modules.
 | [apko_build.this](https://registry.terraform.io/providers/chainguard-dev/apko/latest/docs/resources/build) | resource |
 | [cosign_attest.this](https://registry.terraform.io/providers/chainguard-dev/cosign/latest/docs/resources/attest) | resource |
 | [cosign_sign.signature](https://registry.terraform.io/providers/chainguard-dev/cosign/latest/docs/resources/sign) | resource |
+| [null_resource.check-sbom-ntia](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) | resource |
+| [null_resource.check-sbom-spdx](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) | resource |
 | [apko_config.this](https://registry.terraform.io/providers/chainguard-dev/apko/latest/docs/data-sources/config) | data source |
-| [oci_exec_test.check-sbom-ntia](https://registry.terraform.io/providers/chainguard-dev/oci/latest/docs/data-sources/exec_test) | data source |
-| [oci_exec_test.check-sbom-spdx](https://registry.terraform.io/providers/chainguard-dev/oci/latest/docs/data-sources/exec_test) | data source |
 
 ## Inputs
 

--- a/examples/static/example.tf
+++ b/examples/static/example.tf
@@ -25,7 +25,7 @@ variable "archs" {
 }
 
 variable "check_sbom" {
-  description = "Whether to run the NTIA conformance checker on the SBOMs we are attesting."
+  description = "Whether to run the NTIA conformance checker and SPDX validity test on the SBOMs we are attesting."
   type        = bool
   default     = true
 }

--- a/examples/static/example.tf
+++ b/examples/static/example.tf
@@ -18,10 +18,22 @@ variable "target_repository" {
   description = "The docker repo into which the image and attestations should be published."
 }
 
+variable "archs" {
+  description = "The architectures to build for."
+  type        = list(string)
+  default     = ["x86_64", "aarch64"]
+}
+
+variable "check_sbom" {
+  description = "Whether to run the NTIA conformance checker on the SBOMs we are attesting."
+  type        = bool
+  default     = true
+}
+
 provider "apko" {
   extra_repositories = ["https://packages.wolfi.dev/os"]
   extra_keyring      = ["https://packages.wolfi.dev/os/wolfi-signing.rsa.pub"]
-  default_archs      = ["x86_64", "aarch64"]
+  default_archs      = var.archs
   extra_packages     = ["wolfi-baselayout"]
 }
 
@@ -30,6 +42,8 @@ module "image" {
 
   target_repository = var.target_repository
   config            = file("${path.module}/static.yaml")
+
+  check_sbom = var.check_sbom
 
   # Simulate a "dev" variant
   extra_packages = ["busybox"]

--- a/examples/static/example.tf
+++ b/examples/static/example.tf
@@ -30,6 +30,12 @@ variable "check_sbom" {
   default     = true
 }
 
+variable "verify" {
+  description = "Whether to verify image signatures and attestations."
+  type        = bool
+  default     = true
+}
+
 provider "apko" {
   extra_repositories = ["https://packages.wolfi.dev/os"]
   extra_keyring      = ["https://packages.wolfi.dev/os/wolfi-signing.rsa.pub"]
@@ -54,7 +60,7 @@ module "image" {
 }
 
 data "cosign_verify" "image-signatures" {
-  for_each = module.image.archs
+  for_each = var.verify ? module.image.archs : []
   image    = module.image.arch_to_image[each.key]
 
   policy = jsonencode({
@@ -82,7 +88,7 @@ data "cosign_verify" "image-signatures" {
 }
 
 data "cosign_verify" "sbom-attestations" {
-  for_each = module.image.archs
+  for_each = var.verify ? module.image.archs : []
   image    = module.image.arch_to_image[each.key]
 
   policy = jsonencode({
@@ -121,7 +127,7 @@ data "cosign_verify" "sbom-attestations" {
 }
 
 data "cosign_verify" "config-attestations" {
-  for_each = module.image.archs
+  for_each = var.verify ? module.image.archs : []
   image    = module.image.arch_to_image[each.key]
 
   policy = jsonencode({

--- a/main.tf
+++ b/main.tf
@@ -42,7 +42,7 @@ data "oci_exec_test" "check-sbom-ntia" {
 }
 
 data "oci_exec_test" "check-sbom-spdx" {
-  for_each = var.check_sbom != "" ? local.archs : []
+  for_each = var.check_sbom ? local.archs : []
   digest   = apko_build.this.sboms[each.key].digest
 
   # Run the supplied SPDX checker over the SBOM file mounted into the image in a readonly mode.

--- a/main.tf
+++ b/main.tf
@@ -38,7 +38,11 @@ data "oci_exec_test" "check-sbom-ntia" {
 
   # Run the supplied NTIA checker over the SBOM file mounted into the checker image in a readonly mode.
   # We run as root to avoid permission issues reading the SBOM as the default nonroot user.
-  script = "docker run --rm --user 0 -v ${apko_build.this.sboms[each.key].predicate_path}:/sbom.json:ro ${var.sbom_checker} -v --file /sbom.json"
+  script = <<EOF
+  docker run --rm --user 0 \
+      -v ${apko_build.this.sboms[each.key].predicate_path}:/sbom.json:ro \
+      ${var.sbom_checker} -v --file /sbom.json
+  EOF
 }
 
 data "oci_exec_test" "check-sbom-spdx" {

--- a/variables.tf
+++ b/variables.tf
@@ -4,6 +4,7 @@ SPDX-License-Identifier: Apache-2.0
 */
 
 variable "target_repository" {
+  type        = string
   description = "The docker repo into which the image and attestations should be published."
 }
 
@@ -14,7 +15,8 @@ variable "extra_packages" {
 }
 
 variable "config" {
-  description = "The apko configuration file to build and publish."
+  type        = string
+  description = "The apko configuration file contents to build and publish."
 }
 
 variable "default_annotations" {
@@ -24,21 +26,25 @@ variable "default_annotations" {
 }
 
 variable "check_sbom" {
+  type        = bool
   default     = true
   description = "Whether to run the NTIA conformance checker on the SBOMs we are attesting."
 }
 
 variable "sbom_checker" {
+  type        = string
   default     = "cgr.dev/chainguard/ntia-conformance-checker:latest"
   description = "The NTIA conformance checker image to use to validate SBOMs."
 }
 
 variable "spdx_image" {
+  type        = string
   default     = "cgr.dev/chainguard/wolfi-base:latest"
   description = "The SPDX checker image to use to validate SBOMs."
 }
 
 variable "skip_attest" {
+  type        = bool
   description = "If true, skip the attestations step. This is NOT RECOMMENDED, and should only be used when attestations may be too big for Rekor."
   default     = false
 }


### PR DESCRIPTION
If a caller passed `check_sbom = false` and `archs = ["x86_64"]` the SPDX test would still run (since `false != ""`), but would occasionally fail with `/sbom.json is not a file`. 🤔 

This also moves from oci_exec_test to null_resource (which streams logs), and will run changes to tests in the PR that change them (without signature verification).