### PR TITLE
use prebuilt spdx image

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -63,9 +63,8 @@ resource "null_resource" "check-sbom-spdx" {
     command = <<EOF
   docker run --rm --user 0 \
       -v ${apko_build.this.sboms[each.key].predicate_path}:/sbom.json:ro \
-      --entrypoint sh \
       ${var.spdx_image} \
-      -c "apk add spdx-tools-java && tools-java Verify /sbom.json"
+      Verify /sbom.json
   EOF
   }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -39,7 +39,7 @@ variable "sbom_checker" {
 
 variable "spdx_image" {
   type        = string
-  default     = "cgr.dev/chainguard/wolfi-base:latest"
+  default     = "cgr.dev/chainguard/spdx-tools:latest"
   description = "The SPDX checker image to use to validate SBOMs."
 }
 


### PR DESCRIPTION
...instead of installing `spdx-tools-java` each time the test is run, which can be a lot.