### PR TITLE
GitHub Actions security hardening

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,11 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    cooldown:
+      default-days: 3
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "daily"
+    cooldown:
+      default-days: 3

--- a/.github/workflows/documentation.yaml
+++ b/.github/workflows/documentation.yaml
@@ -3,9 +3,13 @@ name: Generate terraform docs
 on:
   pull_request:
 
+permissions: {}
+
 jobs:
   docs:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read # for actions/checkout to fetch code
     steps:
       - name: Harden the runner (Audit all outbound calls)
         uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4

--- a/.github/workflows/documentation.yaml
+++ b/.github/workflows/documentation.yaml
@@ -14,6 +14,8 @@ jobs:
 
       - name: Checkout code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
       - name: Render terraform docs and fail on diff
         uses: step-security/terraform-docs-action@43f977ff483b4dcf2d1c13fce93bfc30b1164bd9 # v1.4.4
         with:

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -22,6 +22,8 @@ jobs:
 
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@dfe3c3f87815947d99a8997f908cb6525fc44e9e # v4.0.1
       - name: Lint

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -27,9 +27,12 @@ jobs:
       if: github.event_name == 'pull_request_target'
       with:
         ref: refs/pull/${{ github.event.pull_request.number }}/merge
+        persist-credentials: false
 
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       if: github.event_name != 'pull_request_target'
+      with:
+        persist-credentials: false
 
     - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
       with:

--- a/.github/workflows/zizmor.yaml
+++ b/.github/workflows/zizmor.yaml
@@ -9,11 +9,15 @@ on:
     paths:
       - '.github/workflows/**'
       - '.github/actions/**'
+      - '.github/dependabot.yml'
+      - '.github/zizmor.yml'
   push:
     branches: ['main']
     paths:
       - '.github/workflows/**'
       - '.github/actions/**'
+      - '.github/dependabot.yml'
+      - '.github/zizmor.yml'
 
 permissions: {}
 

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,0 +1,12 @@
+rules:
+  # Paired with `cooldown.default-days: 3` in .github/dependabot.yml.
+  dependabot-cooldown:
+    config:
+      days: 3
+  # Cosmetic pedantic-only findings — suppressed across the campaign.
+  anonymous-definition:
+    disable: true
+  undocumented-permissions:
+    disable: true
+  concurrency-limits:
+    disable: true


### PR DESCRIPTION
## Summary

A set of GitHub Actions security-hardening changes surfaced by a `zizmor` audit
of `.github/`. No behavioral change to the build, tests, or docs generation.

## Changes

- **`documentation.yaml`, `main.yaml`, `test.yaml`** — set
  `persist-credentials: false` on the `actions/checkout` steps that have no
  downstream git writes, so the `GITHUB_TOKEN` isn't left in the local git
  config for later steps to read.

- **`documentation.yaml`** — scope the workflow to least-privilege
  `permissions` (workflow-level `permissions: {}` plus the minimal per-job
  grant the docs job needs), so it no longer inherits the broad default token
  scopes.

- **`.github/zizmor.yml` + `.github/dependabot.yml`** — disable the cosmetic
  pedantic-persona rules (`anonymous-definition`, `undocumented-permissions`,
  `concurrency-limits`) and add a 3-day Dependabot `cooldown` to both ecosystems
  (with the matching `zizmor` threshold). The `zizmor` workflow's `paths:` are
  extended to cover both config files so edits to them re-run the audit.

## Testing

- `zizmor` and `actionlint`: no new findings introduced by these changes.
- Patches apply cleanly on top of `main`; all workflows still parse.
- Independently reviewed by a second pass: no blocking issues.

## Note for reviewers

This PR comes from a fork. The provider-credential-dependent `Test` matrix may
show red on a fork PR because it can't access the credentials available to
in-repo runs — that's expected for a fork PR and unrelated to these changes,
which only touch checkout/permissions settings and the `zizmor`/`dependabot`
config.

Refs: PSEC-923