### PR TITLE
Populate SLSA provenance resolvedDependencies with resolved APKs

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -97,7 +97,7 @@ resource "cosign_attest" "this" {
           for pkg in data.apko_config.this.resolved_packages[each.key] : {
             name   = pkg.name
             uri    = pkg.url
-            digest = { apkv2 = pkg.apkv2 }
+            digest = { apkv2 = pkg.checksum }
           }
         ]
 

--- a/main.tf
+++ b/main.tf
@@ -5,6 +5,9 @@ SPDX-License-Identifier: Apache-2.0
 
 terraform {
   required_providers {
+    # NOTE: the `resolved_packages` attribute used below for SLSA
+    # resolvedDependencies requires a provider release that exposes it; bump the
+    # lower bound to that version once it is published.
     apko   = { source = "chainguard-dev/apko", version = ">= 0.29.10" }
     cosign = { source = "chainguard-dev/cosign" }
   }
@@ -85,7 +88,18 @@ resource "cosign_attest" "this" {
       buildDefinition = {
         buildType = "https://apko.dev/slsa-build-type@v1"
         # TODO(mattmoor): consider putting variables into `externalParameters`?
-        # TODO(mattmoor): how do we fit into the shape of `resolvedDependencies`?
+
+        # Document the fully resolved package set as SLSA resolved dependencies:
+        # one ResourceDescriptor per resolved .apk, with its name, download URL,
+        # and APKv2 package checksum
+        # (https://wiki.alpinelinux.org/wiki/Apk_spec#Package_Checksum_Field).
+        resolvedDependencies = [
+          for pkg in data.apko_config.this.resolved_packages[each.key] : {
+            name   = pkg.name
+            uri    = pkg.url
+            digest = { apkv2 = pkg.apkv2 }
+          }
+        ]
 
         # Use internal parameters to document the package resolution.
         internalParameters = {


### PR DESCRIPTION
## Summary

Resolves the long-standing TODO in the SLSA provenance predicate (`main.tf`, `cosign_attest.this`):

```hcl
# TODO(mattmoor): how do we fit into the shape of `resolvedDependencies`?
```

`buildDefinition.resolvedDependencies` is now populated from the `apko_config` data source's new `resolved_packages` attribute — one SLSA `ResourceDescriptor` per resolved `.apk`:

```hcl
resolvedDependencies = [
  for pkg in data.apko_config.this.resolved_packages[each.key] : {
    name   = pkg.name
    uri    = pkg.url
    digest = { apkv2 = pkg.apkv2 }
  }
]
```

Example output (Wolfi, `aarch64`), where `go>1.25` resolves via its `provides` alias to the concrete `go-1.26`:

```json
{
  "name": "go-1.26",
  "uri": "https://packages.wolfi.dev/os/aarch64/go-1.26-1.26.5-r1.apk",
  "digest": { "apkv2": "Q1Cl9julhlqzKC1rUIKE7QiAWRZXs=" }
}
```

## Dependency

Requires the companion provider change that exposes `resolved_packages`: chainguard-dev/terraform-provider-apko#899. Once that ships in a release, bump the `apko` provider version constraint in `main.tf` (a NOTE comment marks the spot).

🤖 Generated with [Claude Code](https://claude.com/claude-code)