### PR TITLE
Add signature_format support

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -66,3 +66,14 @@ jobs:
       run: |
         terraform init -upgrade
         terraform apply -auto-approve
+
+    # Test dual signing (legacy + bundle) via signature_format=both
+    - working-directory: ./examples/static
+      env:
+        TF_VAR_target_repository: localhost:5000/static
+        TF_VAR_archs: '["x86_64"]'
+        TF_VAR_signature_format: both
+        TF_VAR_verify: ${{github.event_name == 'pull_request_target'}}
+      run: |
+        terraform init -upgrade
+        terraform apply -auto-approve

--- a/README.md
+++ b/README.md
@@ -14,13 +14,14 @@ Currently the following supply chain metadata is surfaced:
 | Name | Version |
 |------|---------|
 | <a name="requirement_apko"></a> [apko](#requirement\_apko) | >= 0.29.10 |
+| <a name="requirement_cosign"></a> [cosign](#requirement\_cosign) | >= 0.4.2 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
 | <a name="provider_apko"></a> [apko](#provider\_apko) | >= 0.29.10 |
-| <a name="provider_cosign"></a> [cosign](#provider\_cosign) | n/a |
+| <a name="provider_cosign"></a> [cosign](#provider\_cosign) | >= 0.4.2 |
 | <a name="provider_null"></a> [null](#provider\_null) | n/a |
 
 ## Modules
@@ -45,6 +46,7 @@ No modules.
 | <a name="input_config"></a> [config](#input\_config) | The apko configuration file contents to build and publish. | `string` | n/a | yes |
 | <a name="input_default_annotations"></a> [default\_annotations](#input\_default\_annotations) | Default annotations to apply to this image. | `map(string)` | `{}` | no |
 | <a name="input_extra_packages"></a> [extra\_packages](#input\_extra\_packages) | Additional packages to install into this image. | `list(string)` | `[]` | no |
+| <a name="input_signature_format"></a> [signature\_format](#input\_signature\_format) | Signature format to use for signing. Valid values are 'legacy', 'bundle', or 'both'. Defaults to the provider setting. | `string` | `null` | no |
 | <a name="input_skip_attest"></a> [skip\_attest](#input\_skip\_attest) | If true, skip the attestations step. This is NOT RECOMMENDED, and should only be used when attestations may be too big for Rekor. | `bool` | `false` | no |
 | <a name="input_spdx_image"></a> [spdx\_image](#input\_spdx\_image) | The SPDX checker image to use to validate SBOMs. | `string` | `"ghcr.io/wolfi-dev/spdx-tools:latest"` | no |
 | <a name="input_target_repository"></a> [target\_repository](#input\_target\_repository) | The docker repo into which the image and attestations should be published. | `string` | n/a | yes |

--- a/examples/static/example.tf
+++ b/examples/static/example.tf
@@ -36,6 +36,12 @@ variable "verify" {
   default     = true
 }
 
+variable "signature_format" {
+  description = "Signature format to use for signing. Valid values are 'legacy', 'bundle', or 'both'. Defaults to the provider setting."
+  type        = string
+  default     = null
+}
+
 provider "apko" {
   extra_repositories = ["https://packages.wolfi.dev/os"]
   extra_keyring      = ["https://packages.wolfi.dev/os/wolfi-signing.rsa.pub"]
@@ -50,6 +56,8 @@ module "image" {
   config            = file("${path.module}/static.yaml")
 
   check_sbom = var.check_sbom
+
+  signature_format = var.signature_format
 
   # Simulate a "dev" variant
   extra_packages = ["busybox"]

--- a/main.tf
+++ b/main.tf
@@ -6,7 +6,7 @@ SPDX-License-Identifier: Apache-2.0
 terraform {
   required_providers {
     apko   = { source = "chainguard-dev/apko", version = ">= 0.29.10" }
-    cosign = { source = "chainguard-dev/cosign" }
+    cosign = { source = "chainguard-dev/cosign", version = ">= 0.4.2" }
   }
 }
 
@@ -28,6 +28,8 @@ resource "cosign_sign" "signature" {
 
   # Only keep the latest signature. We use these to ensure we regularly rebuild.
   conflict = "REPLACE"
+
+  signature_format = var.signature_format
 }
 
 locals { archs = toset(concat(["index"], data.apko_config.this.config.archs)) }
@@ -60,6 +62,8 @@ resource "cosign_attest" "this" {
 
   # Do not re-attest things that have not changed.
   conflict = "SKIPSAME"
+
+  signature_format = var.signature_format
 
   # Create SBOM attestations for each architecture.
   predicates {

--- a/variables.tf
+++ b/variables.tf
@@ -42,3 +42,9 @@ variable "skip_attest" {
   description = "If true, skip the attestations step. This is NOT RECOMMENDED, and should only be used when attestations may be too big for Rekor."
   default     = false
 }
+
+variable "signature_format" {
+  type        = string
+  default     = null
+  description = "Signature format to use for signing. Valid values are 'legacy', 'bundle', or 'both'. Defaults to the provider setting."
+}


### PR DESCRIPTION
The cosign provider (>= 0.4.2) can emit OCI 1.1 bundle signatures via a `signature_format` attribute on `cosign_sign` and `cosign_attest`, but this module offers no way to set it, so callers can't opt images into bundle or dual (legacy + bundle) signing. This adds a `signature_format` variable and threads it through to both resources. It defaults to `null`, which defers to the provider's `default_signature_format`, so existing callers see no behavior change.

Note on compatibility: merely declaring the attribute makes terraform reject the config against cosign providers older than 0.4.2, even when the variable is unset. The module now pins `cosign >= 0.4.2` to surface that as a clear version-resolution error instead of an `Unsupported argument` error; callers resolving an older provider will need to upgrade.

A new CI leg applies the example with `signature_format=both` to exercise the plumbing end-to-end.

Assisted by Claude Fable 5