### PR TITLE
git signatures: Allow github verified commits

### DIFF
--- a/.chainguard/source.yaml
+++ b/.chainguard/source.yaml
@@ -10,3 +10,6 @@ spec:
     - key:
         # allow commits signed by GitHub, e.g. the UI
         kms: https://github.com/web-flow.gpg
+  # Allow Github verified ssh, gpg, and smime signatures
+  github:
+    verified: true


### PR DESCRIPTION
Allow github verified commits, like in most other repositories.
